### PR TITLE
Show anchor link on section headings

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,5 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}" class="section-heading">{{ .Text | safeHTML }}
+{{- if in (slice 2 3 4 6) .Level }}{{" " -}}
+<a class="header-link" href="#{{ .Anchor | safeURL }}"><svg class="section-anchor" height="1rem" viewBox="0 0 24 24" width="1rem" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg></a>
+{{- end -}}
+</h{{ .Level }}>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -254,3 +254,12 @@ table td:last-child {
 tbody tr:nth-child(odd) {
   background-color: var(--title-background);
 }
+
+.section-heading .section-anchor {
+    fill: var(--font-color);
+    transition: opacity .05s linear;
+}
+.section-heading:not(:hover) .section-anchor:not(:focus-visible){
+    opacity: 0;
+    transition: opacity 5s linear;
+}


### PR DESCRIPTION
- Added `render-headings.html` adapted from the [gohugoioTheme](https://github.com/gohugoio/gohugoioTheme/blob/master/layouts/_default/_markup/render-heading.html) to display an SVG link icon.
- Added CSS styles to show the icon while covering on the section title, the icon is displayed for an additional 5 seconds before disappearing. This is so that if the user right clicks and copies the link the icon still remains visible when not in focus.