### PR TITLE
Align figures

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -186,6 +186,16 @@ figure img {
     margin-left: auto;
     margin-right: auto;
 }
+figure.alignright {
+    max-width: 25vw;
+    height: auto;
+    float: right;
+}
+figure.alignleft {
+    max-width: 30vw;
+    height: auto;
+    float: left;
+}
 
 @media  only screen and (max-width: 900px) {
     #post-content, nav, main, footer {
@@ -207,7 +217,9 @@ figure img {
         width: 90vw;
         margin: 0rem auto;
     }
-
+    figure.alignright, figure.alignleft {
+        max-width: 100%;
+    }
 }
 
 /* Toots */


### PR DESCRIPTION
Figures can be aligned to the left or right of the page using classes `alignleft` or alignright`. For example:
```
{{<figure src="https://exmaple.png" class="alignleft">}}
```